### PR TITLE
fix: change HTTP verb from GET to POST to restart the app

### DIFF
--- a/src/APIs/OrganizationAPI.php
+++ b/src/APIs/OrganizationAPI.php
@@ -23,7 +23,7 @@ class OrganizationAPI extends API
         }
 
         return $this->cleverCloud->client->request(
-            'GET',
+            'POST',
             "organisations/{$organizationId}/applications/{$applicationId}/instances",
             [
                 'query' => $params,


### PR DESCRIPTION
According to the [documentation](https://www.clever-cloud.com/doc/api/#!/applications/postOrganisationsIdApplicationsAppIdInstances) and my tests, `POST` verb should be use to restart organization application.